### PR TITLE
cart.js: No 'new' on util.error

### DIFF
--- a/api/v1/cart.js
+++ b/api/v1/cart.js
@@ -368,10 +368,10 @@ cart.validateProduct = (schema, data) => {
     var productId = product.id;
     var variantId = product.variant && product.variant.id;
     if (!product.id) {
-      throw new util.error(400, 'Product not found');
+      throw util.error(400, 'Product not found');
     }
     if (product.delivery === 'subscription') {
-      throw new util.error(400, 'Subscription products cannot be added to a cart');
+      throw util.error(400, 'Subscription products cannot be added to a cart');
     }
     if (product.variable && !data.variant_id) {
       // Return first variant
@@ -386,10 +386,10 @@ cart.validateProduct = (schema, data) => {
       });
     }
     if (data.variant_id && !product.variant) {
-      throw new util.error(400, 'Variant not found for this product (' + product.name + ')');
+      throw util.error(400, 'Variant not found for this product (' + product.name + ')');
     }
     if (data.variant_id && !product.variable) {
-      throw new util.error(400, 'Product is not variable (' + product.name + ')');
+      throw util.error(400, 'Product is not variable (' + product.name + ')');
     }
     // Valid
     data.product_id = productId;


### PR DESCRIPTION
If I have a bad product_id when I try to POST to /cart/add-item, I get error messages that start out like this:
```
TypeError: util.error is not a constructor
    at schema.get.then.product (/Users/razoyo-dev/apps2/schema-node-api/api/v1/cart.js:371:13)
```
This change fixes it, but do you want to do `new Error(...` rather than `util.error(...`?